### PR TITLE
Increase spell chanting volume

### DIFF
--- a/script.js
+++ b/script.js
@@ -482,7 +482,7 @@ function speakSpell(spellName) {
     if ('speechSynthesis' in window) {
         const utterance = new SpeechSynthesisUtterance(`${spellName}！`);
         utterance.lang = 'ja-JP';
-        utterance.volume = 1.3; // 音量を130%に設定
+        utterance.volume = 1.5; // 音量を150%に設定
         window.speechSynthesis.cancel();
         window.speechSynthesis.speak(utterance);
     }


### PR DESCRIPTION
## Summary
- Boost chant utterance volume to 150% for clearer incantations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f716b00083308726811ee461a75b